### PR TITLE
Change default table name to a valid table name

### DIFF
--- a/babyagi.py
+++ b/babyagi.py
@@ -10,7 +10,7 @@ PINECONE_API_KEY = ""
 PINECONE_ENVIRONMENT = "us-east1-gcp" #Pinecone Environment (eg. "us-east1-gcp")
 
 #Set Variables
-YOUR_TABLE_NAME = "test_table"
+YOUR_TABLE_NAME = "test-table"
 OBJECTIVE = "Solve world hunger."
 YOUR_FIRST_TASK = "Develop a task list."
 


### PR DESCRIPTION
`test_table` wasn't a valid table name in pinecone because of the underscore