### PR TITLE
Make use of env vars for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ To use the script, you will need to follow these steps:
 1. Install the required packages:
 -openai
 -pinecone
-2. Set your OpenAI and Pinecone API keys in the OPENAI_API_KEY and PINECONE_API_KEY variables.
-3. Set the Pinecone environment in the PINECONE_ENVIRONMENT variable.
+2. Set OpenAI environment variable OPENAI_API_KEY.
+3. Set Pinecone environment variable PINECONE_API_KEY and PINECONE_ENVIRONMENT.
 4. Set the name of the table where the task results will be stored in the YOUR_TABLE_NAME variable.
 5. Set the objective of the task management system in the OBJECTIVE variable.
 6. Set the first task of the system in the YOUR_FIRST_TASK variable.

--- a/babyagi.py
+++ b/babyagi.py
@@ -1,13 +1,9 @@
 import openai
 import pinecone
 import time
+import os
 from collections import deque
 from typing import Dict, List
-
-#Set API Keys
-OPENAI_API_KEY = ""
-PINECONE_API_KEY = ""
-PINECONE_ENVIRONMENT = "us-east1-gcp" #Pinecone Environment (eg. "us-east1-gcp")
 
 #Set Variables
 YOUR_TABLE_NAME = "test_table"
@@ -18,9 +14,11 @@ YOUR_FIRST_TASK = "Develop a task list."
 print("\033[96m\033[1m"+"\n*****OBJECTIVE*****\n"+"\033[0m\033[0m")
 print(OBJECTIVE)
 
-# Configure OpenAI and Pinecone
-openai.api_key = OPENAI_API_KEY
-pinecone.init(api_key=PINECONE_API_KEY, environment=PINECONE_ENVIRONMENT)
+# Configure Pinecone
+pinecone.init(
+    api_key=os.getenv("PINECONE_API_KEY"),
+    environment=os.getenv("PINECONE_ENVIRONMENT", "us-east1-gcp")
+)
 
 # Create Pinecone index
 table_name = YOUR_TABLE_NAME


### PR DESCRIPTION
By default, the OpenAI Library utilizes the  OPENAI_API_KEY  environment variable, so there is no need to specify it in the file.