### PR TITLE
Add support for specifying other gpt models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # API CONFIG
 OPENAI_API_KEY=
-OPENAI_API_MODEL=text-davinci-003 # alternatively, gpt-3.5-turbo, gpt-4, etc
+OPENAI_API_MODEL=gpt-3.5-turbo # alternatively, gpt-4, text-davinci-003, etc
 PINECONE_API_KEY=
 PINECONE_ENVIRONMENT=us-east1-gcp
 

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # API CONFIG
 OPENAI_API_KEY=
+OPENAI_API_MODEL=text-davinci-003 # alternatively, gpt-3.5-turbo, gpt-4, etc
 PINECONE_API_KEY=
 PINECONE_ENVIRONMENT=us-east1-gcp
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To use the script, you will need to follow these steps:
 
 1. Install the required packages: `pip install -r requirements.txt`
 2. Copy the .env.example file to .env: `cp .env.example .env`. This is where you will set the following variables.
-3. Set your OpenAI and Pinecone API keys in the OPENAI_API_KEY and PINECONE_API_KEY variables.
+3. Set your OpenAI and Pinecone API keys in the OPENAI_API_KEY, OPENAPI_API_MODEL, and PINECONE_API_KEY variables.
 4. Set the Pinecone environment in the PINECONE_ENVIRONMENT variable.
 5. Set the name of the table where the task results will be stored in the TABLE_NAME variable.
 6. Set the objective of the task management system in the OBJECTIVE variable. Alternatively you can pass it to the script as a quote argument.

--- a/babyagi.py
+++ b/babyagi.py
@@ -17,7 +17,7 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 assert OPENAI_API_KEY, "OPENAI_API_KEY environment variable is missing from .env"
 
 OPENAI_API_MODEL = os.getenv("OPENAI_API_MODEL", "gpt-3.5-turbo")
-assert OPENAI_API_MODEL, "OPENAI_API_MODEL environment variable is missing from .env from .env"
+assert OPENAI_API_MODEL, "OPENAI_API_MODEL environment variable is missing from .env"
 
 if "gpt-4" in OPENAI_API_MODEL.lower():
     print(f"\033[91m\033[1m"+"\n*****USING GPT-4. POTENTIALLY EXPENSIVE. MONITOR YOUR COSTS*****"+"\033[0m\033[0m")
@@ -100,7 +100,7 @@ def task_creation_agent(objective: str, result: Dict, task_description: str, tas
     new_tasks = response.split('\n')
     return [{"task_name": task_name} for task_name in new_tasks]
 
-def prioritization_agent(this_task_id:int):
+def prioritization_agent(this_task_id: int):
     global task_list
     task_names = [t["task_name"] for t in task_list]
     next_task_id = int(this_task_id)+1
@@ -118,7 +118,7 @@ def prioritization_agent(this_task_id:int):
             task_name = task_parts[1].strip()
             task_list.append({"task_id": task_id, "task_name": task_name})
 
-def execution_agent(objective:str,task: str) -> str:
+def execution_agent(objective: str, task: str) -> str:
     context=context_agent(query=objective, n=5)
     #print("\n*******RELEVANT CONTEXT******\n")
     #print(context)

--- a/babyagi.py
+++ b/babyagi.py
@@ -16,10 +16,9 @@ load_dotenv()
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 assert OPENAI_API_KEY, "OPENAI_API_KEY environment variable is missing from .env"
 
-OPENAI_API_MODEL = os.getenv("OPENAI_API_MODEL", "text-davinci-003")
+OPENAI_API_MODEL = os.getenv("OPENAI_API_MODEL", "gpt-3.5-turbo")
 assert OPENAI_API_MODEL, "OPENAI_API_MODEL environment variable is missing from .env from .env"
 
-USE_CHAT_COMPLETIONS = OPENAI_API_MODEL.lower().startswith("gpt-")
 if "gpt-4" in OPENAI_API_MODEL.lower():
     print(f"\033[91m\033[1m"+"\n*****USING GPT-4. POTENTIALLY EXPENSIVE. MONITOR YOUR COSTS*****"+"\033[0m\033[0m")
 
@@ -69,11 +68,11 @@ def get_ada_embedding(text):
     text = text.replace("\n", " ")
     return openai.Embedding.create(input=[text], model="text-embedding-ada-002")["data"][0]["embedding"]
 
-def openai_call(prompt: str, temperature: float = 0.5, max_tokens: int = 100):
-    if not USE_CHAT_COMPLETIONS:
+def openai_call(prompt: str, model: str = OPENAI_API_MODEL, temperature: float = 0.5, max_tokens: int = 100):
+    if not model.startswith('gpt-'):
         # Use completion API
         response = openai.Completion.create(
-            engine=OPENAI_API_MODEL,
+            engine=model,
             prompt=prompt,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -86,7 +85,7 @@ def openai_call(prompt: str, temperature: float = 0.5, max_tokens: int = 100):
         # Use chat completion API
         messages=[{"role": "user", "content": prompt}]
         response = openai.ChatCompletion.create(
-            model=OPENAI_API_MODEL,
+            model=model,
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -124,7 +123,7 @@ def execution_agent(objective:str,task: str) -> str:
     #print("\n*******RELEVANT CONTEXT******\n")
     #print(context)
     prompt =f"You are an AI who performs one task based on the following objective: {objective}.\nTake into account these previously completed tasks: {context}\nYour task: {task}\nResponse:"
-    return openai_call(prompt, 0.7, 2000)
+    return openai_call(prompt, temperature=0.7, max_tokens=2000)
 
 def context_agent(query: str, n: int):
     query_embedding = get_ada_embedding(query)


### PR DESCRIPTION
This change simply gives the ability to specify the model to use during runtime. If using a gpt-* model, babyagi will use the chat completions API.