### PR TITLE
Use gpt-3.5-turbo as alternative to gpt-4

### DIFF
--- a/babyagi.py
+++ b/babyagi.py
@@ -68,30 +68,17 @@ def get_ada_embedding(text):
     return openai.Embedding.create(input=[text], model="text-embedding-ada-002")["data"][0]["embedding"]
 
 def openai_call(prompt: str, use_gpt4: bool = False, temperature: float = 0.5, max_tokens: int = 100):
-    if not use_gpt4:
-        #Call GPT-3 DaVinci model
-        response = openai.Completion.create(
-            engine='text-davinci-003',
-            prompt=prompt,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            top_p=1,
-            frequency_penalty=0,
-            presence_penalty=0
-        )
-        return response.choices[0].text.strip()
-    else:
-        #Call GPT-4 chat model
-        messages=[{"role": "user", "content": prompt}]
-        response = openai.ChatCompletion.create(
-            model="gpt-4",
-            messages = messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            n=1,
-            stop=None,
-        )
-        return response.choices[0].message.content.strip()
+    #Call GPT Chat model
+    messages=[{"role": "user", "content": prompt}]
+    response = openai.ChatCompletion.create(
+        model="gpt-4" if use_gpt4 else 'gpt-3.5-turbo',
+        messages = messages,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        n=1,
+        stop=None,
+    )
+    return response.choices[0].message.content.strip()
 
 def task_creation_agent(objective: str, result: Dict, task_description: str, task_list: List[str], gpt_version: str = 'gpt-3'):
     prompt = f"You are an task creation AI that uses the result of an execution agent to create new tasks with the following objective: {objective}, The last completed task has the result: {result}. This result was based on this task description: {task_description}. These are incomplete tasks: {', '.join(task_list)}. Based on the result, create new tasks to be completed by the AI system that do not overlap with incomplete tasks. Return the tasks as an array."


### PR DESCRIPTION
This PR is meant to add support for `gpt-3.5-turbo` in a minimal change.
`gpt-3.5-turbo` is significantly cheaper than the previously used `text-davinci-003`, and otherwise just as good.
This also simplifies the codebase, as it's also a chat model and acts as a drop-in replacement for GPT-4.
I've seen PR #11, but that includes more changes that might require some discussion before it can be merged, while this should be fairly uncontroversial. 