### PR TITLE
Remove .env from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-.env
 .idea


### PR DESCRIPTION
Remove .env from .gitignore so the user can copy .env.example when following README instructions