### PR TITLE
Allow an environment argument to support extension configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.env
+.env*
 .idea

--- a/babyagi.py
+++ b/babyagi.py
@@ -10,18 +10,18 @@ from typing import Dict, List
 from dotenv import load_dotenv
 import os
 
-# Parse arguments
+# Parse arguments for optional extensions
 parser = argparse.ArgumentParser()
 parser.add_argument('-e', '--env', nargs='+', help='filenames for env')
 args = parser.parse_args()
 
-# Set environment variables (as extensions)
+# Set environment variables for optional extensions
 if args.env:
     for env_path in args.env:
         load_dotenv(env_path)
         print('Using env from file:', env_path)
 
-# Load default environment variables
+# Load default environment variables (.env)
 load_dotenv()
 
 # Set API Keys

--- a/babyagi.py
+++ b/babyagi.py
@@ -12,15 +12,17 @@ import os
 
 # Parse arguments
 parser = argparse.ArgumentParser()
-parser.add_argument('-e', '--env', help='filename for env')
+parser.add_argument('-e', '--env', nargs='+', help='filenames for env')
 args = parser.parse_args()
 
-# Set environment variables
+# Set environment variables (as extensions)
 if args.env:
-    print('Using env from file:', args.env)
-    load_dotenv(args.env)
-else:
-    load_dotenv()
+    for env_path in args.env:
+        load_dotenv(env_path)
+        print('Using env from file:', env_path)
+
+# Load default environment variables
+load_dotenv()
 
 # Set API Keys
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")

--- a/babyagi.py
+++ b/babyagi.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import os
 import openai
 import pinecone
@@ -9,8 +10,17 @@ from typing import Dict, List
 from dotenv import load_dotenv
 import os
 
-# Set Variables
-load_dotenv()
+# Parse arguments
+parser = argparse.ArgumentParser()
+parser.add_argument('-e', '--env', help='filename for env')
+args = parser.parse_args()
+
+# Set environment variables
+if args.env:
+    print('Using env from file:', args.env)
+    load_dotenv(args.env)
+else:
+    load_dotenv()
 
 # Set API Keys
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
@@ -130,7 +140,7 @@ def context_agent(query: str, n: int):
     results = index.query(query_embedding, top_k=n, include_metadata=True)
     #print("***** RESULTS *****")
     #print(results)
-    sorted_results = sorted(results.matches, key=lambda x: x.score, reverse=True)    
+    sorted_results = sorted(results.matches, key=lambda x: x.score, reverse=True)
     return [(str(item.metadata['task'])) for item in sorted_results]
 
 # Add the first task

--- a/babyagi.py
+++ b/babyagi.py
@@ -15,14 +15,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument('-e', '--env', nargs='+', help='filenames for env')
 args = parser.parse_args()
 
+# Load default environment variables (.env)
+load_dotenv()
+
 # Set environment variables for optional extensions
 if args.env:
     for env_path in args.env:
         load_dotenv(env_path)
         print('Using env from file:', env_path)
-
-# Load default environment variables (.env)
-load_dotenv()
 
 # Set API Keys
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")

--- a/babyagi.py
+++ b/babyagi.py
@@ -43,7 +43,7 @@ YOUR_TABLE_NAME = os.getenv("TABLE_NAME", "")
 assert YOUR_TABLE_NAME, "TABLE_NAME environment variable is missing from .env"
 
 # Project config
-OBJECTIVE = sys.argv[1] if len(sys.argv) > 1 else os.getenv("OBJECTIVE", "")
+OBJECTIVE = os.getenv("OBJECTIVE", "")
 assert OBJECTIVE, "OBJECTIVE environment variable is missing from .env"
 
 YOUR_FIRST_TASK = os.getenv("FIRST_TASK", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openai==0.27.2
 pinecone-client==2.2.1
 python-dotenv==1.0.0
+argparse==1.4.0


### PR DESCRIPTION
Context: https://discord.com/channels/1092917289164230770/1093020282891026554/1093936253478633542

Usage:
```
python3 babyagi.py -e .env .env.test # optionally more files here
```
