### PR TITLE
Remove default pinecone environment

### DIFF
--- a/babyagi.py
+++ b/babyagi.py
@@ -37,7 +37,7 @@ if "gpt-4" in OPENAI_API_MODEL.lower():
 PINECONE_API_KEY = os.getenv("PINECONE_API_KEY", "")
 assert PINECONE_API_KEY, "PINECONE_API_KEY environment variable is missing from .env"
 
-PINECONE_ENVIRONMENT = os.getenv("PINECONE_ENVIRONMENT", "us-east1-gcp")
+PINECONE_ENVIRONMENT = os.getenv("PINECONE_ENVIRONMENT", "")
 assert PINECONE_ENVIRONMENT, "PINECONE_ENVIRONMENT environment variable is missing from .env"
 
 # Table config


### PR DESCRIPTION
Just makes things a little clearer to the user that they should specify their region. Not every environment is us-east1-gcp.