### PR TITLE
Replace Pinecone for FAISS.

### DIFF
--- a/babyagi.py
+++ b/babyagi.py
@@ -168,7 +168,6 @@ def execution_agent(objective: str, task: str) -> str:
 
 
 def context_agent(query: str, n: int):
-    query_embedding = get_ada_embedding(query)
     results = index.similarity_search_with_score(query, k=n)
     # print("***** RESULTS *****")
     # print(results)

--- a/babyagi.py
+++ b/babyagi.py
@@ -70,7 +70,7 @@ openai.api_key = OPENAI_API_KEY
 
 # Create FAISS index
 embeddings_model = OpenAIEmbeddings(model="text-embedding-ada-002")
-index = FAISS.from_texts(["_"], embeddings_model, metadatas=[{"text":"None"}])
+index = FAISS.from_texts(["_"], embeddings_model, metadatas=[{"task":INITIAL_TASK}])
 
 # Task list
 task_list = deque([])
@@ -172,7 +172,7 @@ def context_agent(query: str, n: int):
     # print("***** RESULTS *****")
     # print(results)
     sorted_results = sorted(results, key=lambda x: x[1], reverse=True)
-    return [item[0].page_content for item in sorted_results]
+    return [item[0].metadata["task"] for item in sorted_results]
 
 
 # Add the first task
@@ -204,13 +204,7 @@ while True:
             "data": result
         }  # This is where you should enrich the result if needed
         result_id = f"result_{task['task_id']}"
-        #vector = get_ada_embedding(
-        #    enriched_result["data"]
-        #)  # get vector of the actual result extracted from the dictionary
-        #index.upsert(
-        #    [(result_id, vector, {"task": task["task_name"], "result": result})]
-        #)
-        index.add_texts([result], metadatas=[{"task":task["task_name"], "result":result}])
+        index.add_texts([result], metadatas=[{"task":task["task_name"]}])
 
         # Step 3: Create new tasks and reprioritize task list
         new_tasks = task_creation_agent(

--- a/babyagi.py
+++ b/babyagi.py
@@ -69,7 +69,8 @@ print("\033[93m\033[1m" + "\nInitial task:" + "\033[0m\033[0m" + f" {INITIAL_TAS
 openai.api_key = OPENAI_API_KEY
 
 # Create FAISS index
-index = FAISS.from_texts(["0"], OpenAIEmbeddings(), metadatas=[{"text":"None"}])
+embeddings_model = OpenAIEmbeddings(model="text-embedding-ada-002")
+index = FAISS.from_texts(["_"], embeddings_model, metadatas=[{"text":"None"}])
 
 # Task list
 task_list = deque([])
@@ -77,14 +78,6 @@ task_list = deque([])
 
 def add_task(task: Dict):
     task_list.append(task)
-
-
-def get_ada_embedding(text):
-    text = text.replace("\n", " ")
-    return openai.Embedding.create(input=[text], model="text-embedding-ada-002")[
-        "data"
-    ][0]["embedding"]
-
 
 def openai_call(
     prompt: str,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ openai==0.27.4
 pinecone-client==2.2.1
 pre-commit>=3.2.0
 python-dotenv==1.0.0
+langchain=='0.0.134'
+faiss-cpu
+tiktoken

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ openai==0.27.4
 pinecone-client==2.2.1
 pre-commit>=3.2.0
 python-dotenv==1.0.0
-langchain=='0.0.134'
+langchain>='0.0.100'
 faiss-cpu
 tiktoken


### PR DESCRIPTION
This change replaces pinecone for langchain's wrapper for FAISS vector database.

With this users don't have to get another API key and it makes it all easier to set up.
