### PR TITLE
Separate PineconeDB Upsert/Query By Namespace

### DIFF
--- a/babyagi.py
+++ b/babyagi.py
@@ -198,7 +198,7 @@ def execution_agent(objective: str, task: str) -> str:
 
 def context_agent(query: str, n: int):
     query_embedding = get_ada_embedding(query)
-    results = index.query(query_embedding, top_k=n, include_metadata=True)
+    results = index.query(query_embedding, top_k=n, include_metadata=True, namespace=OBJECTIVE)
     # print("***** RESULTS *****")
     # print(results)
     sorted_results = sorted(results.matches, key=lambda x: x.score, reverse=True)
@@ -238,7 +238,8 @@ while True:
             enriched_result["data"]
         )  # get vector of the actual result extracted from the dictionary
         index.upsert(
-            [(result_id, vector, {"task": task["task_name"], "result": result})]
+            [(result_id, vector, {"task": task["task_name"], "result": result})],
+	    namespace=OBJECTIVE
         )
 
         # Step 3: Create new tasks and reprioritize task list


### PR DESCRIPTION
Separate query/upsert by namespace to avoid cross contamination of data for separate objectives. 

Enables trying multiple objectives on pineconeDB free tier without having to clear the index each time to avoid cross contamination of previous chat history to a new objective.

**Test Steps**
1. Run with default objective "End world hunger"
2. `python babyagi.py`
3. Update objective to "Summarize what inputs you have received previously"
4. `python babyagi.py`
5. Confirm response shows babyagi has no memory of previous tasks
6. `python babyagi.py`
7. Confirm response shows babyagi remembers being asked about previous tasks