### PR TITLE
add wildcard to venv/ in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ __pycache__/
 .env.*
 env/
 .venv
-venv/
+*venv/
 
 .vscode/
 .idea/


### PR DESCRIPTION
### Context
Issue #162 
### Changes
Changes line 9 in the `.gitignore` from `venv/` to `*venv/`

Thanks, gn.