### PR TITLE
More exception handling for OpenAI API errors

### DIFF
--- a/babyagi.py
+++ b/babyagi.py
@@ -170,7 +170,32 @@ def openai_call(
                 return response.choices[0].message.content.strip()
         except openai.error.RateLimitError:
             print(
-                "The OpenAI API rate limit has been exceeded. Waiting 10 seconds and trying again."
+                "   *** The OpenAI API rate limit has been exceeded. Waiting 10 seconds and trying again. ***"
+            )
+            time.sleep(10)  # Wait 10 seconds and try again
+        except openai.error.Timeout:
+            print(
+                "   *** OpenAI API timeout occured. Waiting 10 seconds and trying again. ***"
+            )
+            time.sleep(10)  # Wait 10 seconds and try again
+        except openai.error.APIError:
+            print(
+                "   *** OpenAI API error occured. Waiting 10 seconds and trying again. ***"
+            )
+            time.sleep(10)  # Wait 10 seconds and try again
+        except openai.error.APIConnectionError:
+            print(
+                "   *** OpenAI API connection error occured. Check your network settings, proxy configuration, SSL certificates, or firewall rules. Waiting 10 seconds and trying again. ***"
+            )
+            time.sleep(10)  # Wait 10 seconds and try again
+        except openai.error.InvalidRequestError:
+            print(
+                "   *** OpenAI API invalid request. Check the documentation for the specific API method you are calling and make sure you are sending valid and complete parameters. Waiting 10 seconds and trying again. ***"
+            )
+            time.sleep(10)  # Wait 10 seconds and try again
+        except openai.error.ServiceUnavailableError:
+            print(
+                "   *** OpenAI API service unavailable. Waiting 10 seconds and trying again. ***"
             )
             time.sleep(10)  # Wait 10 seconds and try again
         else:


### PR DESCRIPTION
Adding exception handling for further OpenAI API errors as e.g. timeout or general API error and beautification for the log output in terminal.

Background is that I did observe sporadic runtime errors. The error log did point to "BadGateway" or "GatewayTimeout" in most cases and once or twice "Timeout". With the changes I have far fewer abortions and as a consequence significantly longer (unobserved) runtime for this awesome baby... :-)

Hope this is useful for other people as well. Maybe I am not the only one having such problems.