### PR TITLE
Fix invalid requirements-cooperative.txt file

### DIFF
--- a/requirements-cooperative.txt
+++ b/requirements-cooperative.txt
@@ -1,2 +1,1 @@
--r requirements.txt
 ray==2.3.1


### PR DESCRIPTION
Part of the installation command seems to have found it's way into the requirements file. This removes it.