### PR TITLE
Moving llama-cpp requirement to extensions

### DIFF
--- a/extensions/requirements.txt
+++ b/extensions/requirements.txt
@@ -1,2 +1,3 @@
 ray==2.3.1
 pinecone-client==2.2.1
+llama-cpp-python>=0.1.35


### PR DESCRIPTION
Llama-cpp py byndings are not required for the main script, but needed for extensions