### PR TITLE
Limit tokens to OpenAI calls to around 4000.

### DIFF
--- a/babyagi.py
+++ b/babyagi.py
@@ -7,6 +7,7 @@ from typing import Dict, List
 import importlib
 import openai
 import chromadb
+import tiktoken as tiktoken
 from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
 from dotenv import load_dotenv
 
@@ -261,6 +262,21 @@ elif COOPERATIVE_MODE in ['d', 'distributed']:
     pass
 
 
+def limit_tokens_from_string(string: str, model: str, limit: int) -> str:
+    """Limits the string to a number of tokens (estimated)."""
+
+    try:
+        encoding = tiktoken.encoding_for_model(model)
+    except:
+        encoding = tiktoken.encoding_for_model('gpt2')  # Fallback for others.
+
+    encoded = encoding.encode(string)
+    print(f"encoded length: {len(encoded)}")
+    print(f"limiting to {limit}")
+
+    return encoding.decode(encoded[:limit])
+
+
 def openai_call(
     prompt: str,
     model: str = LLM_MODEL,
@@ -287,8 +303,13 @@ def openai_call(
                 )
                 return response.choices[0].text.strip()
             else:
+                # Use 4000 instead of the real limit (4097) to give a bit of wiggle room for the encoding of roles.
+                # TODO: different limits for different models.
+
+                trimmed_prompt = limit_tokens_from_string(prompt, model, 4000 - max_tokens)
+
                 # Use chat completion API
-                messages = [{"role": "system", "content": prompt}]
+                messages = [{"role": "system", "content": trimmed_prompt}]
                 response = openai.ChatCompletion.create(
                     model=model,
                     messages=messages,

--- a/babyagi.py
+++ b/babyagi.py
@@ -271,8 +271,6 @@ def limit_tokens_from_string(string: str, model: str, limit: int) -> str:
         encoding = tiktoken.encoding_for_model('gpt2')  # Fallback for others.
 
     encoded = encoding.encode(string)
-    print(f"encoded length: {len(encoded)}")
-    print(f"limiting to {limit}")
 
     return encoding.decode(encoded[:limit])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openai==0.27.4
 chromadb==0.3.21
 pre-commit>=3.2.0
 python-dotenv==1.0.0
+tiktoken==0.3.3


### PR DESCRIPTION
Prevents token limit exceeded exceptions.