### PR TITLE
load env before loading openai, support OPENAI_API_BASE

### DIFF
--- a/babyagi.py
+++ b/babyagi.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+from dotenv import load_dotenv
+# Load default environment variables (.env)
+load_dotenv()
+
 import os
 import time
 import logging
@@ -10,15 +14,12 @@ import chromadb
 import tiktoken as tiktoken
 from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
 from chromadb.api.types import Documents, EmbeddingFunction, Embeddings
-from dotenv import load_dotenv
 import re
 
 # default opt out of chromadb telemetry.
 from chromadb.config import Settings
 client = chromadb.Client(Settings(anonymized_telemetry=False))
 
-# Load default environment variables (.env)
-load_dotenv()
 
 # Engine configuration
 


### PR DESCRIPTION
OPENAI_API_BASE is a standard environment variable which the openai module will use when it loads. The OPENAI_API_BASE lets you redirect the API to a compatible service. I have such an API in a pull request for oobabooga/text-generation-webui over here: https://github.com/oobabooga/text-generation-webui/pull/1475. With this small change the babyagi code will work unchanged with that. 
