### PR TITLE
Add missing openai config in tools scripts

### DIFF
--- a/tools/results.py
+++ b/tools/results.py
@@ -39,6 +39,9 @@ def main():
     ''', default=[os.getenv("OBJECTIVE", "")])
     args = parser.parse_args()
 
+    # Configure OpenAI
+    openai.api_key = OPENAI_API_KEY
+
     # Initialize Pinecone
     pinecone.init(api_key=PINECONE_API_KEY)
 

--- a/tools/results_browser.py
+++ b/tools/results_browser.py
@@ -65,6 +65,9 @@ def draw_summary(stdscr, objective, tasks, start, num):
     stdscr.addstr(1, 1, summary_text[:stdscr.getmaxyx()[1] - 2])
 
 def main(stdscr):
+    # Configure OpenAI
+    openai.api_key = OPENAI_API_KEY
+
     # Initialize Pinecone
     pinecone.init(api_key=PINECONE_API_KEY)
 


### PR DESCRIPTION
Fix error `"openai.error.AuthenticationError: No API key provided."` when running `results.py` & `results_browser.py` scripts.