### PR TITLE
Link to 7-day github activity reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ To help the BabyAGI community stay informed about the project's progress, [Bluep
 
 To view the BabyAGI 7-day activity report, go here: [https://app.blueprint.ai/github/yoheinakajima/babyagi](https://app.blueprint.ai/github/yoheinakajima/babyagi)
 
+[<img width="293" alt="image" src="https://user-images.githubusercontent.com/334530/235789974-f49d3cbe-f4df-4c3d-89e9-bfb60eea6308.png">](https://app.blueprint.ai/github/yoheinakajima/babyagi)
+
+
 # Inspired projects
 
 In the short time since it was release, BabyAGI inspired many projects. You can see them all [here](docs/inspired-projects.md).

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ A note from @yoheinakajima (Apr 5th, 2023):
 
 I am new to GitHub and open source, so please be patient as I learn to manage this project properly. I run a VC firm by day, so I will generally be checking PRs and issues at night after I get my kids down - which may not be every night. Open to the idea of bringing in support, will be updating this section soon (expectations, visions, etc). Talking to lots of people and learning - hang tight for updates!
 
+# BabyAGI Activity Report
+
+To help the BabyAGI community stay informed about the project's progress, [Blueprint AI](https://blueprint.ai) has developed a Github activity summarizer for BabyAGI. This concise report displays a summary of all contributions to the BabyAGI repository over the past 7 days (continuously updated), making it easy for you to keep track of the latest developments.
+
+To view the BabyAGI 7-day activity report, go here: [https://app.blueprint.ai/github/yoheinakajima/babyagi](https://app.blueprint.ai/github/yoheinakajima/babyagi)
+
 # Inspired projects
 
 In the short time since it was release, BabyAGI inspired many projects. You can see them all [here](docs/inspired-projects.md).

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ I am new to GitHub and open source, so please be patient as I learn to manage th
 
 # BabyAGI Activity Report
 
-To help the BabyAGI community stay informed about the project's progress, [Blueprint AI](https://blueprint.ai) has developed a Github activity summarizer for BabyAGI. This concise report displays a summary of all contributions to the BabyAGI repository over the past 7 days (continuously updated), making it easy for you to keep track of the latest developments.
+To help the BabyAGI community stay informed about the project's progress, Blueprint AI has developed a Github activity summarizer for BabyAGI. This concise report displays a summary of all contributions to the BabyAGI repository over the past 7 days (continuously updated), making it easy for you to keep track of the latest developments.
 
 To view the BabyAGI 7-day activity report, go here: [https://app.blueprint.ai/github/yoheinakajima/babyagi](https://app.blueprint.ai/github/yoheinakajima/babyagi)
 


### PR DESCRIPTION
Add 7-day activity report link for BabyAGI community to help everyone stay up-to-date on project contributions. The report covers all changes in the git repo for the last 7 days is kept continuously up-to-date.